### PR TITLE
SELC-2716 Refactor mapping nationalRegistries response for AdELegal

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/constant/AdEResultCodeEnum.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/constant/AdEResultCodeEnum.java
@@ -1,16 +1,20 @@
-package it.pagopa.selfcare.party.registry_proxy.connector.rest.model;
+package it.pagopa.selfcare.party.registry_proxy.connector.constant;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum AdEResultCodeEnum {
 
-        _00("00"),
+        CODE_00("00"),
 
-        _01("01"),
+        CODE_01("01"),
 
-        _02("02");
+        CODE_02("02"),
 
-        private String value;
+        CODE_03("03"),
+
+        UNKNOWN("UNKNOWN");
+
+        private final String value;
 
         AdEResultCodeEnum(String value) {
             this.value = value;

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/constant/AdEResultDetailEnum.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/constant/AdEResultDetailEnum.java
@@ -1,4 +1,4 @@
-package it.pagopa.selfcare.party.registry_proxy.connector.rest.model;
+package it.pagopa.selfcare.party.registry_proxy.connector.constant;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -17,7 +17,7 @@ public enum AdEResultDetailEnum {
 
     XXXX("XXXX");
 
-    private String value;
+    private final String value;
 
     AdEResultDetailEnum(String value) {
         this.value = value;
@@ -27,4 +27,14 @@ public enum AdEResultDetailEnum {
     public String getValue() {
         return value;
     }
+
+    public static AdEResultDetailEnum fromValue(String code) {
+        for (AdEResultDetailEnum b : AdEResultDetailEnum.values()) {
+            if (b.value.equals(code)) {
+                return b;
+            }
+        }
+        return AdEResultDetailEnum.XXXX;
+    }
+
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/InternalException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/InternalException.java
@@ -6,4 +6,8 @@ public class InternalException extends RuntimeException{
         super(cause);
     }
 
+    public InternalException(){
+        super();
+    }
+
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/InvalidRequestException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/InvalidRequestException.java
@@ -1,0 +1,8 @@
+package it.pagopa.selfcare.party.registry_proxy.connector.exception;
+
+public class InvalidRequestException extends RuntimeException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/nationalregistries/VerifyLegalResponse.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/nationalregistries/VerifyLegalResponse.java
@@ -1,11 +1,14 @@
 package it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries;
 
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import lombok.Data;
 
 @Data
 public class VerifyLegalResponse {
 
     private boolean verificationResult = false;
-    private String verifyLegalResultCode;
-    private String verifyLegalResultDetail;
+    private AdEResultCodeEnum verifyLegalResultCode;
+    private AdEResultDetailEnum verifyLegalResultDetail;
+    private String verifyLegalResultDetailMessage;
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImpl.java
@@ -6,6 +6,7 @@ import it.pagopa.selfcare.party.registry_proxy.connector.rest.client.NationalReg
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
 @Slf4j
 @Service
@@ -56,12 +57,15 @@ public class NationalRegistriesConnectorImpl implements NationalRegistriesConnec
     }
 
     private VerifyLegalResponse toVerifyLegalResponse(AdELegalOKDto adELegalOKDto) {
+        Assert.notNull(adELegalOKDto.getResultDetail(), "ResultDetail is required");
+        Assert.notNull(adELegalOKDto.getResultCode(), "ResultCode is required");
         VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
         if(adELegalOKDto.getVerificationResult() != null){
             verifyLegalResponse.setVerificationResult(adELegalOKDto.getVerificationResult());
         }
-        verifyLegalResponse.setVerifyLegalResultDetail(adELegalOKDto.getResultDetail().getValue());
-        verifyLegalResponse.setVerifyLegalResultCode(adELegalOKDto.getResultCode().getValue());
+        verifyLegalResponse.setVerifyLegalResultDetail(adELegalOKDto.getResultDetail());
+        verifyLegalResponse.setVerifyLegalResultCode(adELegalOKDto.getResultCode());
+        verifyLegalResponse.setVerifyLegalResultDetailMessage(adELegalOKDto.getResultDetailMessage());
         return verifyLegalResponse;
     }
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/model/AdELegalOKDto.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/model/AdELegalOKDto.java
@@ -1,9 +1,13 @@
 package it.pagopa.selfcare.party.registry_proxy.connector.rest.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdELegalOKDto {
 
     @JsonProperty("verificationResult")
@@ -11,6 +15,9 @@ public class AdELegalOKDto {
 
     @JsonProperty("resultDetail")
     private AdEResultDetailEnum resultDetail;
+
+    @JsonProperty("resultDetailMessage")
+    private String resultDetailMessage;
 
     @JsonProperty("resultCode")
     private AdEResultCodeEnum resultCode;

--- a/connector/rest/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImplTest.java
@@ -3,8 +3,8 @@ package it.pagopa.selfcare.party.registry_proxy.connector.rest;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.*;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.client.NationalRegistriesRestClient;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.AdELegalOKDto;
-import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.AdEResultCodeEnum;
-import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.AdEResultDetailEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.GetAddressRegistroImpreseOKDto;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.ProfessionalAddressDto;
 import org.junit.jupiter.api.Test;
@@ -112,14 +112,15 @@ class NationalRegistriesConnectorImplTest {
     @Test
     void testVerifyLegal() {
         AdELegalOKDto adELegalOKDto = new AdELegalOKDto();
-        adELegalOKDto.setResultCode(AdEResultCodeEnum._00);
+        adELegalOKDto.setResultCode(AdEResultCodeEnum.CODE_00);
         adELegalOKDto.setResultDetail(AdEResultDetailEnum.XX00);
+        adELegalOKDto.setResultDetailMessage("Detail Message");
         adELegalOKDto.setVerificationResult(true);
         when(nationalRegistriesRestClient.verifyLegal(any())).thenReturn(adELegalOKDto);
         VerifyLegalResponse actualVerifyLegalResult = nationalRegistriesConnectorImpl.verifyLegal("42", "42");
-        assertEquals("00", actualVerifyLegalResult.getVerifyLegalResultCode());
+        assertEquals("00", actualVerifyLegalResult.getVerifyLegalResultCode().getValue());
         assertTrue(actualVerifyLegalResult.isVerificationResult());
-        assertEquals("XX00", actualVerifyLegalResult.getVerifyLegalResultDetail());
+        assertEquals("XX00", actualVerifyLegalResult.getVerifyLegalResultDetail().getValue());
         verify(nationalRegistriesRestClient).verifyLegal(any());
     }
 
@@ -129,13 +130,14 @@ class NationalRegistriesConnectorImplTest {
     @Test
     void testVerifyLegalWithoutVerificationCode() {
         AdELegalOKDto adELegalOKDto = new AdELegalOKDto();
-        adELegalOKDto.setResultCode(AdEResultCodeEnum._00);
+        adELegalOKDto.setResultCode(AdEResultCodeEnum.CODE_00);
         adELegalOKDto.setResultDetail(AdEResultDetailEnum.XX00);
+        adELegalOKDto.setResultDetailMessage("Detail Message");
         when(nationalRegistriesRestClient.verifyLegal(any())).thenReturn(adELegalOKDto);
         VerifyLegalResponse actualVerifyLegalResult = nationalRegistriesConnectorImpl.verifyLegal("42", "42");
-        assertEquals("00", actualVerifyLegalResult.getVerifyLegalResultCode());
+        assertEquals("00", actualVerifyLegalResult.getVerifyLegalResultCode().getValue());
         assertFalse(actualVerifyLegalResult.isVerificationResult());
-        assertEquals("XX00", actualVerifyLegalResult.getVerifyLegalResultDetail());
+        assertEquals("XX00", actualVerifyLegalResult.getVerifyLegalResultDetail().getValue());
         verify(nationalRegistriesRestClient).verifyLegal(any());
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImplTest.java
@@ -11,6 +11,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import it.pagopa.selfcare.party.registry_proxy.connector.api.NationalRegistriesConnector;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.InternalException;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.InvalidRequestException;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.Businesses;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressProfessionalResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressResponse;
@@ -104,10 +108,20 @@ class NationalRegistriesServiceImplTest {
     void testVerifyLegal() {
         VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
         verifyLegalResponse.setVerificationResult(true);
-        verifyLegalResponse.setVerifyLegalResultCode("Verify Legal Result Code");
-        verifyLegalResponse.setVerifyLegalResultDetail("Verify Legal Result Detail");
+        verifyLegalResponse.setVerifyLegalResultCode(AdEResultCodeEnum.CODE_00);
+        verifyLegalResponse.setVerifyLegalResultDetail(AdEResultDetailEnum.XX00);
         when(nationalRegistriesConnector.verifyLegal(any(), any())).thenReturn(verifyLegalResponse);
         assertSame(verifyLegalResponse, nationalRegistriesServiceImpl.verifyLegal("42", "42"));
+        verify(nationalRegistriesConnector).verifyLegal(any(), any());
+    }
+
+    @Test
+    void testVerifyLegalError() {
+        VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
+        verifyLegalResponse.setVerifyLegalResultCode(AdEResultCodeEnum.CODE_02);
+        verifyLegalResponse.setVerifyLegalResultDetail(AdEResultDetailEnum.XX03);
+        when(nationalRegistriesConnector.verifyLegal(any(), any())).thenReturn(verifyLegalResponse);
+        assertThrows(InternalException.class, () -> nationalRegistriesServiceImpl.verifyLegal("42", "42"));
         verify(nationalRegistriesConnector).verifyLegal(any(), any());
     }
 
@@ -115,10 +129,13 @@ class NationalRegistriesServiceImplTest {
      * Method under test: {@link NationalRegistriesServiceImpl#verifyLegal(String, String)}
      */
     @Test
-    void testVerifyLegal2() {
+    void testVerifyLegalInvalidRequest() {
+        VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
+        verifyLegalResponse.setVerifyLegalResultCode(AdEResultCodeEnum.CODE_01);
+        verifyLegalResponse.setVerifyLegalResultDetail(AdEResultDetailEnum.XX01);
         when(nationalRegistriesConnector.verifyLegal(any(), any()))
-                .thenThrow(new ResourceNotFoundException());
-        assertThrows(ResourceNotFoundException.class, () -> nationalRegistriesServiceImpl.verifyLegal("42", "42"));
+                .thenReturn(verifyLegalResponse);
+        assertThrows(InvalidRequestException.class, () -> nationalRegistriesServiceImpl.verifyLegal("42", "42"));
         verify(nationalRegistriesConnector).verifyLegal(any(), any());
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/handler/PartyRegistryProxyExceptionHandler.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/handler/PartyRegistryProxyExceptionHandler.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.party.registry_proxy.web.handler;
 import feign.FeignException;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.commons.web.model.mapper.ProblemMapper;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.InvalidRequestException;
 import it.pagopa.selfcare.party.registry_proxy.core.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.party.registry_proxy.web.exception.ValidationFailedException;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,12 @@ public class PartyRegistryProxyExceptionHandler {
     ResponseEntity<Problem> handleResourceNotFoundException(ResourceNotFoundException e) {
         log.warn(e.toString());
         return ProblemMapper.toResponseEntity(new Problem(NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler({InvalidRequestException.class})
+    ResponseEntity<Problem> handleInvalidRequestException(InvalidRequestException e) {
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(BAD_REQUEST, e.getMessage()));
     }
 
     @ExceptionHandler({ValidationFailedException.class})

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/mapper/NationalRegistriesMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/mapper/NationalRegistriesMapper.java
@@ -34,8 +34,8 @@ public class NationalRegistriesMapper {
 
     public static LegalVerificationResult toResult(VerifyLegalResponse response) {
         LegalVerificationResult legalVerificationResult = new LegalVerificationResult();
-        legalVerificationResult.setResultCode(response.getVerifyLegalResultCode());
-        legalVerificationResult.setResultDetail(response.getVerifyLegalResultDetail());
+        legalVerificationResult.setResultCode(response.getVerifyLegalResultCode().getValue());
+        legalVerificationResult.setResultDetail(response.getVerifyLegalResultDetail().getValue());
         legalVerificationResult.setVerificationResult(response.isVerificationResult());
         return legalVerificationResult;
     }

--- a/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/controller/NationalRegistriesControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/controller/NationalRegistriesControllerTest.java
@@ -1,5 +1,7 @@
 package it.pagopa.selfcare.party.registry_proxy.web.controller;
 
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
+import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressProfessionalResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.VerifyLegalResponse;
 import it.pagopa.selfcare.party.registry_proxy.core.NationalRegistriesService;
@@ -56,8 +58,8 @@ class NationalRegistriesControllerTest {
     void testVerifyLegal() throws Exception {
         VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
         verifyLegalResponse.setVerificationResult(true);
-        verifyLegalResponse.setVerifyLegalResultCode("Verify Legal Result Code");
-        verifyLegalResponse.setVerifyLegalResultDetail("Verify Legal Result Detail");
+        verifyLegalResponse.setVerifyLegalResultCode(AdEResultCodeEnum.CODE_01);
+        verifyLegalResponse.setVerifyLegalResultDetail(AdEResultDetailEnum.XX01);
         when(nationalRegistriesService.verifyLegal(any(), any())).thenReturn(verifyLegalResponse);
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/national-registries/verify-legal")
                 .param("taxId", "CIACIA80A01H501X")
@@ -69,8 +71,7 @@ class NationalRegistriesControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"verificationResult\":true,\"resultCode\":\"Verify Legal Result Code\",\"resultDetail\":\"Verify Legal Result"
-                                        + " Detail\"}"));
+                                "{\"verificationResult\":true,\"resultCode\":\"01\",\"resultDetail\":\"XX01\"}"));
     }
 }
 

--- a/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/handler/PartyRegistryProxyExceptionHandlerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/handler/PartyRegistryProxyExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.party.registry_proxy.web.handler;
 
 import feign.FeignException;
 import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.InvalidRequestException;
 import it.pagopa.selfcare.party.registry_proxy.core.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.party.registry_proxy.web.exception.ValidationFailedException;
 import org.junit.jupiter.api.Test;
@@ -11,8 +12,7 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 class PartyRegistryProxyExceptionHandlerTest {
 
@@ -33,6 +33,22 @@ class PartyRegistryProxyExceptionHandlerTest {
         assertNotNull(responseEntity.getBody());
         assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
         assertEquals(NOT_FOUND.value(), responseEntity.getBody().getStatus());
+    }
+
+    @Test
+    void handleInvalidRequestException() {
+        //given
+        InvalidRequestException mockException = Mockito.mock(InvalidRequestException.class);
+        Mockito.when(mockException.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        //when
+        ResponseEntity<Problem> responseEntity = handler.handleInvalidRequestException(mockException);
+        //then
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(BAD_REQUEST.value(), responseEntity.getBody().getStatus());
     }
 
     /**


### PR DESCRIPTION
#### List of Changes

- Add resultDetailMessage in NR AdE response
- Add check on resultDetail code to throws Exception 

#### Motivation and Context

- AdE gives HttpStatus 200 for response with error (invalidRequest, generic Error)

#### How Has This Been Tested?

- Try to call verify-legal Api with this test cases:

1. taxId=GLLLSN70L30B819D&vatNumber= 07077320963 (200 ok with verification result true)
2. taxId=BBTRLL89R44G273R&vatNumber= 07886221006 (200 ok with verification result false)
3. taxId=FLNDVD98L15H501X&vatNumber=FLNDVD98L15H501X (500)
4. taxId=FLNDVD98L15H501X&vatNumber=42947449007 (400)

