### PR TITLE
Added method to retrieve file from azure storage

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/FileStorageConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/FileStorageConnector.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.party.registry_proxy.connector.api;
+
+import it.pagopa.selfcare.party.registry_proxy.connector.model.ResourceResponse;
+
+public interface FileStorageConnector {
+
+    ResourceResponse getFile(String fileName);
+
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/ProxyRegistryException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/ProxyRegistryException.java
@@ -1,0 +1,15 @@
+package it.pagopa.selfcare.party.registry_proxy.connector.exception;
+
+public class ProxyRegistryException extends RuntimeException {
+
+    private final String code;
+
+    public ProxyRegistryException(String message, String code) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/ResourceResponse.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/ResourceResponse.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.party.registry_proxy.connector.model;
+
+import lombok.Data;
+
+@Data
+public class ResourceResponse {
+    private byte[] data;
+    private String fileName;
+    private String mimetype;
+}

--- a/connector-api/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/ProxyRegistryExceptionTest.java
+++ b/connector-api/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/exception/ProxyRegistryExceptionTest.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.party.registry_proxy.connector.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProxyRegistryExceptionTest {
+    @Test
+    void testConstructor() {
+        assertEquals("Code", (new ProxyRegistryException("An error occurred", "Code")).getCode());
+    }
+}
+

--- a/connector/azure_storage/pom.xml
+++ b/connector/azure_storage/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>it.pagopa.selfcare.party</groupId>
+        <artifactId>selc-party-registry-proxy</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>selc-party-registry-proxy-azure-storage</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage</artifactId>
+            <version>8.6.6</version>
+        </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare.party</groupId>
+            <artifactId>selc-party-registry-proxy-connector-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AzureBlobClient.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AzureBlobClient.java
@@ -1,0 +1,74 @@
+package it.pagopa.selfcare.party.connector.azure_storage;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobProperties;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import it.pagopa.selfcare.party.registry_proxy.connector.api.FileStorageConnector;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.ProxyRegistryException;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.party.registry_proxy.connector.model.ResourceResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+
+@Slf4j
+@Service
+@PropertySource("classpath:config/azure-storage-config.properties")
+@Profile("AzureStorage")
+class AzureBlobClient implements FileStorageConnector {
+
+    private static final String  ERROR_DURING_DOWNLOAD_FILE_MESSAGE = "Error during download file %s";
+    private static final String  ERROR_DURING_DOWNLOAD_FILE_CODE =  "0000";
+    private final CloudBlobClient blobClient;
+    private  final String containerReference;
+
+    AzureBlobClient(@Value("${blobStorage.connectionString}") String storageConnectionString,
+                    @Value("${blobStorage.containerReference}") String containerReference)
+            throws URISyntaxException, InvalidKeyException {
+        if (log.isDebugEnabled()) {
+            log.trace("AzureBlobClient");
+            log.debug("AzureBlobClient storageConnectionString = {}, containerReference = {}",
+                    storageConnectionString, containerReference);
+        }
+        final CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
+        this.blobClient = storageAccount.createCloudBlobClient();
+        this.containerReference = containerReference;
+    }
+
+    @Override
+    public ResourceResponse getFile(String fileName) {
+        log.info("START - getFile for path: {}", fileName);
+        try {
+            ResourceResponse response = new ResourceResponse();
+            final CloudBlobContainer blobContainer = blobClient.getContainerReference(containerReference);
+            final CloudBlockBlob blob = blobContainer.getBlockBlobReference(fileName);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BlobProperties properties = blob.getProperties();
+            blob.download(outputStream);
+            log.info("END - getFile - path {}", fileName);
+            response.setData(outputStream.toByteArray());
+            response.setFileName(blob.getName());
+            response.setMimetype(properties.getContentType());
+            return response;
+        } catch (StorageException e) {
+            if (e.getHttpStatusCode() == 404) {
+                throw new ResourceNotFoundException(String.format(ERROR_DURING_DOWNLOAD_FILE_MESSAGE, fileName));
+            }
+            throw new ProxyRegistryException(String.format(ERROR_DURING_DOWNLOAD_FILE_MESSAGE, fileName),
+                    ERROR_DURING_DOWNLOAD_FILE_CODE);
+        } catch (URISyntaxException e) {
+            throw new ProxyRegistryException(String.format(ERROR_DURING_DOWNLOAD_FILE_MESSAGE, fileName),
+                    ERROR_DURING_DOWNLOAD_FILE_CODE);
+        }
+    }
+
+}

--- a/connector/azure_storage/src/main/resources/config/azure-storage-config.properties
+++ b/connector/azure_storage/src/main/resources/config/azure-storage-config.properties
@@ -1,0 +1,2 @@
+blobStorage.connectionString=${BLOB_STORAGE_CONN_STRING:UseDevelopmentStorage=true;}
+blobStorage.containerReference=${BLOB_CONTAINER_REF:$web}

--- a/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/AzureBlobClientTest.java
+++ b/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/AzureBlobClientTest.java
@@ -1,0 +1,54 @@
+package it.pagopa.selfcare.party.connector.azure_storage;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobProperties;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+
+class AzureBlobClientTest {
+
+    @Test
+    void getFileOk() throws URISyntaxException, IOException, NoSuchFieldException, IllegalAccessException, StorageException, InvalidKeyException {
+        //given
+        AzureBlobClient blobClient = new AzureBlobClient("UseDevelopmentStorage=true;", "$web");
+        CloudBlockBlob blockBlobMock = Mockito.mock(CloudBlockBlob.class);
+        Mockito.when(blockBlobMock.getProperties())
+                .thenReturn(new BlobProperties());
+        Mockito.doNothing().
+                when(blockBlobMock).upload(Mockito.any(), Mockito.anyByte());
+        CloudBlobContainer blobContainerMock = Mockito.mock(CloudBlobContainer.class);
+        Mockito.when(blobContainerMock.getBlockBlobReference(Mockito.anyString()))
+                .thenReturn(blockBlobMock);
+        CloudBlobClient blobClientMock = Mockito.mock(CloudBlobClient.class);
+        Mockito.when(blobClientMock.getContainerReference("$web"))
+                .thenReturn(blobContainerMock);
+        mockCloudBlobClient(blobClient, blobClientMock);
+
+        Executable executable = () -> blobClient.getFile("logo-pagopa-spa.png");
+        // then
+        Assertions.assertDoesNotThrow(executable);
+    }
+
+    private void mockCloudBlobClient(AzureBlobClient blobClient, CloudBlobClient blobClientMock) throws NoSuchFieldException, IllegalAccessException {
+        Field field = AzureBlobClient.class.getDeclaredField("blobClient");
+        field.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+        field.set(blobClient, blobClientMock);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <module>app</module>
     <module>connector-api</module>
     <module>connector</module>
+    <module>connector/azure_storage</module>
   </modules>
 
 


### PR DESCRIPTION
#### List of Changes

Added method to retrieve file from azure storage

#### Motivation and Context

This change was necessary in order to retrieve ANAC data and build and search index on them. So an Azure client has been created to get blob and process it.

#### How Has This Been Tested?

File on storage does not exist yet, so tests are limited to unit tests.