### PR TITLE
[SELC-3278] feat: added format rule on tax code

### DIFF
--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
+
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(of = "taxCode")
@@ -22,4 +24,11 @@ public class AnacDataTemplate implements Station {
     private boolean anacEngaged;
     @CsvBindByName(column = "ANAC_abilitato")
     private boolean anacEnabled;
+
+    public String getTaxCode() {
+        if(this.taxCode.length() < 11) {
+            return String.join("", Collections.nCopies(11 - taxCode.length(), "0")) + this.taxCode;
+        }
+        return this.taxCode;
+    }
 }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 
@@ -27,7 +28,7 @@ public class AnacDataTemplate implements Station {
 
     public String getTaxCode() {
         if(this.taxCode.length() < 11) {
-            return String.join("", Collections.nCopies(11 - taxCode.length(), "0")) + this.taxCode;
+            return StringUtils.leftPad(this.taxCode, 11, "0");
         }
         return this.taxCode;
     }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/IvassDataTemplate.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/IvassDataTemplate.java
@@ -6,10 +6,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
+
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(of = "taxCode")
 public class IvassDataTemplate implements InsuranceCompany {
+
     @CsvBindByName(column = "CODICE_IVASS")
     private String originId;
     @CsvBindByName(column = "CODICE_FISCALE")
@@ -24,4 +27,11 @@ public class IvassDataTemplate implements InsuranceCompany {
     private String registerType;
     @CsvBindByName(column = "INDIRIZZO_SEDE_LEGALE_RAPPRESENTANZA_IN_ITALIA")
     private String address;
+
+    public String getTaxCode() {
+        if(this.taxCode.length() < 11) {
+            return String.join("", Collections.nCopies(11 - taxCode.length(), "0")) + this.taxCode;
+        }
+        return this.taxCode;
+    }
 }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/IvassDataTemplate.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/IvassDataTemplate.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.party.registry_proxy.connector.model.InsuranceCompany;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 
@@ -30,7 +31,7 @@ public class IvassDataTemplate implements InsuranceCompany {
 
     public String getTaxCode() {
         if(this.taxCode.length() < 11) {
-            return String.join("", Collections.nCopies(11 - taxCode.length(), "0")) + this.taxCode;
+            return StringUtils.leftPad(this.taxCode, 11, "0");
         }
         return this.taxCode;
     }


### PR DESCRIPTION
#### List of Changes

Added a rule to prepend n zeros to taxCode

#### Motivation and Context

When IVASS and ANAC csv is read, some fiscal codes can have less than 11 digits. In order to avoid validation errors on frontend side, it has been decided to prepend n zeros to tax code where n is the difference between tax code's length and correct amount of digits for fiscal code (11) 

#### How Has This Been Tested?

I have run the microservice locally aiming to dev environment.