### PR TITLE
[SELC-3305] feat: added filter on getInsurance from IVASS registry

### DIFF
--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
@@ -67,7 +67,10 @@ public class IvassDataConnectorImpl implements IvassDataConnector {
                 .filter(company -> StringUtils.hasText(company.getTaxCode())
                         && StringUtils.hasText(company.getDigitalAddress())
                         && workTypesAdmitted.contains(company.getWorkType())
-                        && registryTypesAdmitted.stream().anyMatch(StringUtils.trimTrailingWhitespace(company.getRegisterType().split("-")[0])::equals))
+                        && registryTypesAdmitted
+                        .stream()
+                        .anyMatch(StringUtils.trimAllWhitespace(company.getRegisterType()
+                                .split("-")[0])::equals))
                 .collect(Collectors.toList());
     }
 }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
@@ -9,6 +9,7 @@ import it.pagopa.selfcare.party.registry_proxy.connector.model.InsuranceCompany;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.ResourceResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -22,17 +23,23 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@PropertySource("classpath:config/ivass-config.properties")
 public class IvassDataConnectorImpl implements IvassDataConnector {
 
     private final FileStorageConnector fileStorageConnector;
     private final String sourceFilename;
+    private final List<String> registryTypesAdmitted;
+    private final List<String> workTypesAdmitted;
 
     public IvassDataConnectorImpl(@Value("${blobStorage.ivass.filename}") String ivassCsvFileName,
+                                  @Value("#{'${ivass.registryTypes.admitted}'.split(',')}") List<String> registryTypes,
+                                  @Value("#{'${ivass.workTypes.admitted}'.split(',')}") List<String> registryWorkTypes,
                                   FileStorageConnector fileStorageConnector) {
         this.fileStorageConnector = fileStorageConnector;
+        this.registryTypesAdmitted = registryTypes;
+        this.workTypesAdmitted = registryWorkTypes;
         this.sourceFilename = ivassCsvFileName;
     }
-
     @Override
     public List<InsuranceCompany> getInsurances() {
         log.trace("getInsurances start");
@@ -56,8 +63,11 @@ public class IvassDataConnectorImpl implements IvassDataConnector {
         log.debug("getInsurances result = {}", companies);
         log.trace("getInsurances end");
         return companies
-                    .stream()
-                    .filter(company -> StringUtils.hasText(company.getTaxCode()) && StringUtils.hasText(company.getDigitalAddress()))
-                    .collect(Collectors.toList());
+                .stream()
+                .filter(company -> StringUtils.hasText(company.getTaxCode())
+                        && StringUtils.hasText(company.getDigitalAddress())
+                        && workTypesAdmitted.contains(company.getWorkType())
+                        && registryTypesAdmitted.stream().anyMatch(StringUtils.trimTrailingWhitespace(company.getRegisterType().split("-")[0])::equals))
+                .collect(Collectors.toList());
     }
 }

--- a/connector/azure_storage/src/main/resources/config/ivass-config.properties
+++ b/connector/azure_storage/src/main/resources/config/ivass-config.properties
@@ -1,0 +1,2 @@
+ivass.registryTypes.admitted=${IVASS_REGISTRY_TYPES:Elenco I,Elenco II,Sezione I,Sezione II}
+ivass.workTypes.admitted=${IVASS_WORK_TYPES:VITA,PICCOLO CUMULO,MISTA}

--- a/connector/azure_storage/src/main/resources/config/ivass-config.properties
+++ b/connector/azure_storage/src/main/resources/config/ivass-config.properties
@@ -1,2 +1,2 @@
-ivass.registryTypes.admitted=${IVASS_REGISTRY_TYPES:Elenco I,Elenco II,Sezione I,Sezione II}
+ivass.registryTypes.admitted=${IVASS_REGISTRY_TYPES:ElencoI,ElencoII,SezioneI,SezioneII}
 ivass.workTypes.admitted=${IVASS_WORK_TYPES:VITA,PICCOLO CUMULO,MISTA}

--- a/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImplTest.java
+++ b/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImplTest.java
@@ -40,7 +40,7 @@ class IvassDataConnectorImplTest {
     @Test
     void getInsurancesFilteredByRegistryType() {
         final String filename = "test.csv";
-        IvassDataConnector ivassDataConnector = new IvassDataConnectorImpl(filename, List.of("Elenco I", "Elenco II"), List.of("DANNI"), azureBlobClientMock);
+        IvassDataConnector ivassDataConnector = new IvassDataConnectorImpl(filename, List.of("ElencoI", "ElencoII"), List.of("DANNI"), azureBlobClientMock);
         ResourceResponse response = new ResourceResponse();
         String bytes = "CODICE_IVASS;CODICE_FISCALE;DENOMINAZIONE_IMPRESA;PEC;TIPO_LAVORO;TIPO_ALBO\n" +
                 "aaaaaaa;codice_test;denominazione_test;test@pec.it;DANNI;Elenco II - imprese\n";
@@ -56,7 +56,7 @@ class IvassDataConnectorImplTest {
     @Test
     void getInsurancesFilteredByWorkType() {
         final String filename = "test.csv";
-        IvassDataConnector ivassDataConnector = new IvassDataConnectorImpl(filename, List.of("Elenco I"), List.of("DANNO"), azureBlobClientMock);
+        IvassDataConnector ivassDataConnector = new IvassDataConnectorImpl(filename, List.of("ElencoI"), List.of("DANNO"), azureBlobClientMock);
         ResourceResponse response = new ResourceResponse();
         String bytes = "CODICE_IVASS;CODICE_FISCALE;DENOMINAZIONE_IMPRESA;PEC;TIPO_LAVORO;TIPO_ALBO\n" +
                 "aaaaaaa;codice_test;denominazione_test;test@pec.it;DANNI;Elenco I - imprese\n";

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -118,3 +118,5 @@ config:
   LUCENE_INDEX_IVASS_FOLDER: "index/ivass"
   BLOB_ANAC_FILENAME: "anac-data.csv"
   BLOB_IVASS_FILENAME: "ivass-data.csv"
+  IVASS_REGISTRY_TYPES: "Elenco I,Elenco II,Sezione I,Sezione II"
+  IVASS_WORK_TYPES: "VITA,PICCOLO CUMULO,MISTA"


### PR DESCRIPTION
#### List of Changes

Added filters on getInsurance from IVASS registry

#### Motivation and Context

Insurance companies that can onboard are retrieved from IVASS registry; this registry, by the way, contains also insurances that don't match eligibility crietria. In particular, from CSV file of IVASS, are excluded companies with:

- empty tax code
- empty pec
-  work type different from **VITA,PICCOLO CUMULO,MISTA**
- register type different from **Elenco I,Elenco II,Sezione I,Sezione II**

#### How Has This Been Tested?

I have deployed the feature branch in DEV environment and test this exclusion usign api **/insurance-companies/{taxCode}** or **/insurance-companies/search={text}**

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.