### PR TITLE
fix: update helm variables for IVASS registry

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -118,5 +118,5 @@ config:
   LUCENE_INDEX_IVASS_FOLDER: "index/ivass"
   BLOB_ANAC_FILENAME: "anac-data.csv"
   BLOB_IVASS_FILENAME: "ivass-data.csv"
-  IVASS_REGISTRY_TYPES: "Elenco I,Elenco II,Sezione I,Sezione II"
+  IVASS_REGISTRY_TYPES: "ElencoI,ElencoII,SezioneI,SezioneII"
   IVASS_WORK_TYPES: "VITA,PICCOLO CUMULO,MISTA"


### PR DESCRIPTION
#### List of Changes

Update helm variables for IVASS registry

#### Motivation and Context

This change was necessary to avoid trim errors linked to IVASS filters.

#### How Has This Been Tested?

I have run the microservice locally and tested the api **/insurance-companies/{taxCode}**
