### PR TITLE
[SELC-3394] Feat: Added retry for NationalRegistries API

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -36,7 +36,7 @@ resilience4j:
   retry:
     retry-aspect-order: 2
     instances:
-      retry503:
+      retryServiceUnavailable:
         max-attempts: 3
         wait-duration: 5s
         enable-exponential-backoff: true

--- a/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/GeoTaxonomiesConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/GeoTaxonomiesConnectorImpl.java
@@ -5,7 +5,6 @@ import io.github.resilience4j.retry.annotation.Retry;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.GeoTaxonomiesConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
-import it.pagopa.selfcare.party.registry_proxy.connector.exception.ServiceUnavailableException;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.GeographicTaxonomy;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.client.GeoTaxonomiesRestClient;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.model.geotaxonomy.GeographicTaxonomiesResponse;
@@ -34,7 +33,7 @@ public class GeoTaxonomiesConnectorImpl implements GeoTaxonomiesConnector {
 
     @Override
     @CircuitBreaker(name = "geotaxCircuitbreaker", fallbackMethod = "fallbackGetExtByDescription")
-    @Retry(name = "retry503")
+    @Retry(name = "retryServiceUnavailable")
     public List<GeographicTaxonomy> getExtByDescription(String description, Integer offset, Integer limit) {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getExtByDescription description = {}", description);
         Assert.hasText(description, "Description is required");
@@ -52,7 +51,7 @@ public class GeoTaxonomiesConnectorImpl implements GeoTaxonomiesConnector {
 
     @Override
     @CircuitBreaker(name = "geotaxCircuitbreaker", fallbackMethod = "fallbackGetExtByCode")
-    @Retry(name = "retry503")
+    @Retry(name = "retryServiceUnavailable")
     public GeographicTaxonomy getExtByCode(String code) {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getExtByCode code = {}", code);
         Assert.hasText(code, "Code is required");

--- a/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/rest/NationalRegistriesConnectorImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.party.registry_proxy.connector.rest;
 
+import io.github.resilience4j.retry.annotation.Retry;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.NationalRegistriesConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.*;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.client.NationalRegistriesRestClient;
@@ -19,18 +20,21 @@ public class NationalRegistriesConnectorImpl implements NationalRegistriesConnec
     }
 
     @Override
+    @Retry(name = "retryServiceUnavailable")
     public LegalAddressResponse getLegalAddress(String taxCode) {
         LegalAddressRequest legalAddressRequest = createLegalAddressRequest(taxCode);
         return toLegalAddressResponse(nationalRegistriesRestClient.getLegalAddress(legalAddressRequest));
     }
 
     @Override
+    @Retry(name = "retryServiceUnavailable")
     public VerifyLegalResponse verifyLegal(String taxId, String vatNumber) {
         AdELegalRequestBodyDto request = createRequest(taxId, vatNumber);
         return toVerifyLegalResponse(nationalRegistriesRestClient.verifyLegal(request));
     }
 
     @Override
+    @Retry(name = "retryServiceUnavailable")
     public Businesses institutionsByLegalTaxId(String legalTaxId) {
         log.info("start institutionsByLegalTaxId");
         LegalInstitutionsRequestBody request = createLegalInstitutionsRequest(legalTaxId);


### PR DESCRIPTION
#### List of Changes

- Added retry for NationalRegistries API

#### Motivation and Context

- Some NationalRegistries API invocations throws an exception for clientTimeout, so we need to check this kind of exception to trigger the retry 

#### How Has This Been Tested?
- local environment