### PR TITLE
[SELC-3489] feat: update station model to avoid parse errors on boolean fields

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/Station.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/model/Station.java
@@ -15,9 +15,9 @@ public interface Station {
 
     String getDigitalAddress();
 
-    boolean isAnacEngaged();
+    String getAnacEngaged();
 
-    boolean isAnacEnabled();
+    String getAnacEnabled();
 
     default Origin getOrigin() {
         return Origin.ANAC;

--- a/connector-api/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/model/DummyPDND.java
+++ b/connector-api/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/model/DummyPDND.java
@@ -12,7 +12,7 @@ public class DummyPDND implements Station {
     private String taxCode;
     private String description;
     private String digitalAddress;
-    private boolean anacEnabled;
-    private boolean anacEngaged;
+    private String anacEnabled;
+    private String anacEngaged;
 
 }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/model/AnacDataTemplate.java
@@ -22,9 +22,9 @@ public class AnacDataTemplate implements Station {
     @CsvBindByName(column = "PEC")
     private String digitalAddress;
     @CsvBindByName(column = "ANAC_incaricato")
-    private boolean anacEngaged;
+    private String anacEngaged;
     @CsvBindByName(column = "ANAC_abilitato")
-    private boolean anacEnabled;
+    private String anacEnabled;
 
     public String getTaxCode() {
         if(this.taxCode.length() < 11) {

--- a/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/StationToDocumentConverter.java
+++ b/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/StationToDocumentConverter.java
@@ -25,8 +25,8 @@ public class StationToDocumentConverter implements Function<Station, Document> {
             doc.add(new TextField(DESCRIPTION.toString(), station.getDescription(), Field.Store.YES));
             doc.add(new StoredField(TAX_CODE.toString(), station.getTaxCode()));
             doc.add(new StoredField(DIGITAL_ADDRESS.toString(), station.getDigitalAddress()));
-            doc.add(new StoredField(ANAC_ENABLED.toString(), String.valueOf(station.isAnacEnabled())));
-            doc.add(new StoredField(ANAC_ENGAGED.toString(), String.valueOf(station.isAnacEngaged())));
+            doc.add(new StoredField(ANAC_ENABLED.toString(), station.getAnacEnabled()));
+            doc.add(new StoredField(ANAC_ENGAGED.toString(), station.getAnacEngaged()));
         }
         return doc;
     }

--- a/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/model/StationEntity.java
+++ b/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/model/StationEntity.java
@@ -14,8 +14,8 @@ public class StationEntity implements Station {
 
     private String id;
     private String originId;
-    private boolean anacEnabled;
-    private boolean anacEngaged;
+    private String anacEnabled;
+    private String anacEngaged;
     private String taxCode;
     private String description;
     private String digitalAddress;

--- a/connector/lucene/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/StationToDocumentConverterTest.java
+++ b/connector/lucene/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/StationToDocumentConverterTest.java
@@ -45,8 +45,8 @@ class StationToDocumentConverterTest {
         assertEquals(input.getTaxCode(), output.get(Field.TAX_CODE.toString()));
         assertEquals(input.getDescription(), output.get(Field.DESCRIPTION.toString()));
         assertEquals(input.getDigitalAddress(), output.get(Field.DIGITAL_ADDRESS.toString()));
-        assertTrue(input.isAnacEnabled(), output.get(Field.ANAC_ENABLED.toString()));
-        assertTrue(input.isAnacEngaged(), output.get(Field.ANAC_ENGAGED.toString()));
+        assertEquals(input.getAnacEnabled(), output.get(Field.ANAC_ENABLED.toString()));
+        assertEquals(input.getAnacEngaged(), output.get(Field.ANAC_ENGAGED.toString()));
         final Set<String> fieldValues = Arrays.stream(Field.values())
                 .map(Field::toString)
                 .collect(Collectors.toSet());
@@ -67,8 +67,8 @@ class StationToDocumentConverterTest {
         assertEquals(input.getTaxCode(), output.get(Field.TAX_CODE.toString()));
         assertEquals(input.getDescription(), output.get(Field.DESCRIPTION.toString()));
         assertEquals(input.getDigitalAddress(), output.get(Field.DIGITAL_ADDRESS.toString()));
-        assertTrue(input.isAnacEnabled(), output.get(Field.ANAC_ENABLED.toString()));
-        assertTrue(input.isAnacEngaged(), output.get(Field.ANAC_ENGAGED.toString()));
+        assertEquals(input.getAnacEnabled(), output.get(Field.ANAC_ENABLED.toString()));
+        assertEquals(input.getAnacEngaged(), output.get(Field.ANAC_ENGAGED.toString()));
         final Set<String> fieldValues = Arrays.stream(Field.values())
                 .map(Field::toString)
                 .collect(Collectors.toSet());

--- a/connector/lucene/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/model/DummyStation.java
+++ b/connector/lucene/src/test/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/model/DummyStation.java
@@ -45,13 +45,13 @@ public class DummyStation implements Station {
     }
 
     @Override
-    public boolean isAnacEnabled() {
-        return dummyEntity.isAnacEnabled();
+    public String getAnacEnabled() {
+        return dummyEntity.getAnacEnabled();
     }
 
     @Override
-    public boolean isAnacEngaged() {
-        return dummyEntity.isAnacEngaged();
+    public String getAnacEngaged() {
+        return dummyEntity.getAnacEngaged();
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/DummyPDND.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/DummyPDND.java
@@ -13,7 +13,7 @@ public class DummyPDND implements Station {
     private String taxCode;
     private String description;
     private String digitalAddress;
-    private boolean anacEnabled;
-    private boolean anacEngaged;
+    private String anacEnabled;
+    private String anacEngaged;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/StationResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/StationResource.java
@@ -2,11 +2,10 @@ package it.pagopa.selfcare.party.registry_proxy.web.model;
 
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.Origin;
-import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
 import lombok.Data;
 
 @Data
-public class StationResource implements Station {
+public class StationResource {
 
     @ApiModelProperty(value = "${swagger.model.station.id}")
     private String id;

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/mapper/StationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/model/mapper/StationMapper.java
@@ -3,9 +3,21 @@ package it.pagopa.selfcare.party.registry_proxy.web.model.mapper;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
 import it.pagopa.selfcare.party.registry_proxy.web.model.StationResource;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.Objects;
 
 @Mapper(componentModel = "spring")
 public interface StationMapper {
+
+    @Mapping(source = "anacEngaged", target = "anacEngaged", qualifiedByName = "convertToBoolean")
+    @Mapping(source = "anacEnabled", target = "anacEnabled", qualifiedByName = "convertToBoolean")
     StationResource toResource(Station station);
+
+    @Named("convertToBoolean")
+    default boolean convertToBoolean(String value) {
+        return Objects.nonNull(value) ? Boolean.parseBoolean(value.trim()) : false;
+    }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/model/DummyPDND.java
+++ b/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/model/DummyPDND.java
@@ -14,8 +14,8 @@ public class DummyPDND implements Station {
     private String taxCode;
     private String description;
     private String digitalAddress;
-    private boolean anacEnabled;
-    private boolean anacEngaged;
+    private String anacEnabled;
+    private String anacEngaged;
     private Origin origin;
 
 }


### PR DESCRIPTION
#### List of Changes

Update station model to avoid parse errors on boolean fields

#### Motivation and Context

Into ANAC file, the fields **anacEngaged** and **anacEnabled** have often a space char in addition to their value. In order to avoid parse errors while processing the file, boolean fields into Station model have been changed in strings.

#### How Has This Been Tested?

I have run the microservice locally and tested the process of index creation using a malformed file. In addition to this, I have also tested the api **/stations** and **/stations?search={value}**