### PR TITLE
[SELC-3514] Feat: - ANAC file update in AzureStorage

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/AnacDataConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/AnacDataConnector.java
@@ -1,8 +1,8 @@
 package it.pagopa.selfcare.party.registry_proxy.connector.api;
 
-import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.util.Optional;
 
 public interface AnacDataConnector {
-    Optional<InputStream> getANACData();
+    Optional<ByteArrayInputStream> getANACData();
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/FileStorageConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/api/FileStorageConnector.java
@@ -1,8 +1,11 @@
 package it.pagopa.selfcare.party.registry_proxy.connector.api;
 
 import it.pagopa.selfcare.party.registry_proxy.connector.model.ResourceResponse;
+import java.io.InputStream;
 
 public interface FileStorageConnector {
     ResourceResponse getFile(String fileName);
+
+    void uploadFile(InputStream file, String fileName);
 
 }

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImpl.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImpl.java
@@ -29,7 +29,7 @@ public class AnacDataConnectorImpl implements AnacDataConnector {
     }
 
     @Override
-    public Optional<InputStream> getANACData() {
+    public Optional<ByteArrayInputStream> getANACData() {
         ResourceResponse resourceResponse;
         try {
             resourceResponse = fileStorageConnector.getFile(fileName);

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/client/AzureBlobClient.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/client/AzureBlobClient.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 
@@ -29,6 +30,8 @@ public class AzureBlobClient implements FileStorageConnector {
 
     private static final String ERROR_DURING_DOWNLOAD_FILE_MESSAGE = "Error during download file %s";
     private static final String ERROR_DURING_DOWNLOAD_FILE_CODE = "0000";
+    private static final String ERROR_DURING_UPLOAD_FILE_MESSAGE = "Error during upload file %s";
+    private static final String ERROR_DURING_UPLOAD_FILE_CODE = "0000";
     private final CloudBlobClient blobClient;
     private final String containerReference;
 
@@ -71,4 +74,18 @@ public class AzureBlobClient implements FileStorageConnector {
         }
     }
 
+    @Override
+    public void uploadFile(InputStream file, String fileName) {
+        log.info("START - uploadFile for path: {}", fileName);
+        try {
+            final CloudBlobContainer blobContainer = blobClient.getContainerReference(containerReference);
+            final CloudBlockBlob blob = blobContainer.getBlockBlobReference(fileName);
+            blob.upload(file, file.available());
+            log.info("Uploaded {}", fileName);
+        } catch (StorageException | URISyntaxException | IOException e) {
+            log.error(String.format(ERROR_DURING_UPLOAD_FILE_MESSAGE, fileName), e);
+            throw new ProxyRegistryException(String.format(ERROR_DURING_UPLOAD_FILE_MESSAGE, fileName),
+                    ERROR_DURING_UPLOAD_FILE_CODE);
+        }
+    }
 }

--- a/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImplTest.java
+++ b/connector/azure_storage/src/test/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImplTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
@@ -34,7 +34,7 @@ class AnacDataConnectorImplTest {
                 """;
         response.setData(bytes.getBytes(StandardCharsets.UTF_8));
         when(azureBlobClientMock.getFile(anyString())).thenReturn(response);
-        final Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertNotNull(inputStream);
         verify(azureBlobClientMock, times(1)).getFile(filename);
         verifyNoMoreInteractions(azureBlobClientMock);
@@ -45,7 +45,7 @@ class AnacDataConnectorImplTest {
         final String filename = "test.csv";
         AnacDataConnector anacDataConnector = new AnacDataConnectorImpl(filename, azureBlobClientMock);
         when(azureBlobClientMock.getFile(anyString())).thenThrow(ResourceNotFoundException.class);
-        final  Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final  Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertTrue(inputStream.isEmpty());
         verify(azureBlobClientMock, times(1)).getFile(filename);
         verifyNoMoreInteractions(azureBlobClientMock);
@@ -63,7 +63,7 @@ class AnacDataConnectorImplTest {
                 """;
         response.setData(bytes.getBytes(StandardCharsets.UTF_8));
         when(azureBlobClientMock.getFile(anyString())).thenReturn(response);
-        final  Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final  Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertTrue(inputStream.isPresent());
         verify(azureBlobClientMock, times(1)).getFile(filename);
         verifyNoMoreInteractions(azureBlobClientMock);
@@ -74,7 +74,7 @@ class AnacDataConnectorImplTest {
         final String filename = "test.csv";
         AnacDataConnector anacDataConnector = new AnacDataConnectorImpl(filename, azureBlobClientMock);
         when(azureBlobClientMock.getFile(anyString())).thenThrow(ResourceNotFoundException.class);
-        final  Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final  Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertTrue(inputStream.isEmpty());
         verify(azureBlobClientMock, times(1)).getFile(filename);
         verifyNoMoreInteractions(azureBlobClientMock);

--- a/connector/ftp/pom.xml
+++ b/connector/ftp/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>jsch</artifactId>
             <version>0.1.55</version>
         </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare.party</groupId>
+            <artifactId>selc-party-registry-proxy-connector-azure-storage</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
+++ b/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
@@ -46,19 +46,19 @@ public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
      * If there is no such file, it returns an empty Optional InputStream. Otherwise, it uploads that InputStream to Azure Blob Storage to update the last ANAC file and returns it as well.
      */
     @Override
-    public Optional<InputStream> getANACData() {
+    public Optional<ByteArrayInputStream> getANACData() {
         String fileName = createFileName();
         log.trace("getANACData on filename: {} start", fileName);
         Optional<InputStream> optionalFile = ftpConnector.getFile(directory + fileName);
         return optionalFile.flatMap(inputStream -> {
-            Optional<InputStream> opt = updateFileOnAzureStorageAndRetrieveInputStream(inputStream);
+            Optional<ByteArrayInputStream> opt = updateFileOnAzureStorageAndRetrieveInputStream(inputStream);
             log.trace("getANACData on filename: {} end", fileName);
             return opt;
         });
 
     }
 
-    private Optional<InputStream> updateFileOnAzureStorageAndRetrieveInputStream(InputStream inputStream){
+    private Optional<ByteArrayInputStream> updateFileOnAzureStorageAndRetrieveInputStream(InputStream inputStream){
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             IOUtils.copy(inputStream, out);
@@ -66,6 +66,7 @@ public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
             azureBlobClient.uploadFile(new ByteArrayInputStream(bytes), anacFileName);
             return Optional.of(new ByteArrayInputStream(bytes));
         } catch (IOException e) {
+            log.error("Error during retrieving ANAC csv. Error: {}", e.getMessage(), e);
             return Optional.empty();
         }
     }

--- a/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
+++ b/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
@@ -1,8 +1,10 @@
 package it.pagopa.selfcare.party.connector.ftp;
 
+import it.pagopa.selfcare.party.connector.azure_storage.client.AzureBlobClient;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.AnacDataConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.FTPConnector;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.PropertySource;
@@ -25,21 +27,47 @@ public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
     private static final String ANAC_DATA_FILE_SUFFIX = ".csv";
     private final String directory;
     private final FTPConnector ftpConnector;
+    private final AzureBlobClient azureBlobClient;
 
+    private final String anacFileName;
     public AnacDataFromFTPConnectorImpl(@Value("${anac.ftp.directory}") String anacDirectory,
-                                        FTPConnector ftpConnector) {
+                                        @Value("${blobStorage.anac.filename}") String anacFileName,
+                                        FTPConnector ftpConnector, AzureBlobClient azureBlobClient) {
         this.ftpConnector = ftpConnector;
         this.directory = anacDirectory;
+        this.azureBlobClient = azureBlobClient;
+        this.anacFileName = anacFileName;
     }
 
 
+    /**
+     * The getANACData function is used to retrieve the ANAC data from the FTP server.
+     * The function first creates a file name based on the current date and time, then uses this file name to get an InputStream of that file from the FTP server.
+     * If there is no such file, it returns an empty Optional InputStream. Otherwise, it uploads that InputStream to Azure Blob Storage to update the last ANAC file and returns it as well.
+     */
     @Override
     public Optional<InputStream> getANACData() {
         String fileName = createFileName();
         log.trace("getANACData on filename: {} start", fileName);
-        Optional<InputStream> optionalInputStream = ftpConnector.getFile(directory + fileName);
-        log.trace("getANACData on filename: {} end", fileName);
-        return optionalInputStream;
+        Optional<InputStream> optionalFile = ftpConnector.getFile(directory + fileName);
+        return optionalFile.flatMap(inputStream -> {
+            Optional<InputStream> opt = updateFileOnAzureStorageAndRetrieveInputStream(inputStream);
+            log.trace("getANACData on filename: {} end", fileName);
+            return opt;
+        });
+
+    }
+
+    private Optional<InputStream> updateFileOnAzureStorageAndRetrieveInputStream(InputStream inputStream){
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IOUtils.copy(inputStream, out);
+            byte[] bytes = out.toByteArray();
+            azureBlobClient.uploadFile(new ByteArrayInputStream(bytes), anacFileName);
+            return Optional.of(new ByteArrayInputStream(bytes));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
     }
 
     private String createFileName() {

--- a/connector/ftp/src/test/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImplTest.java
+++ b/connector/ftp/src/test/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImplTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.party.connector.ftp;
 
+import it.pagopa.selfcare.party.connector.azure_storage.client.AzureBlobClient;
 import it.pagopa.selfcare.party.connector.ftp.client.AnacFTPClient;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.AnacDataConnector;
 import org.junit.jupiter.api.Test;
@@ -21,10 +22,14 @@ class AnacDataFromFTPConnectorImplTest {
     @Mock
     private AnacFTPClient ftpClient;
 
+    @Mock
+    private AzureBlobClient azureBlobClient;
+
     @Test
     void getStationsFound() {
         final String filename = "test.csv";
-        AnacDataConnector anacDataConnector = new AnacDataFromFTPConnectorImpl(filename, ftpClient);
+        final String directory = "/test/";
+        AnacDataConnector anacDataConnector = new AnacDataFromFTPConnectorImpl(directory, filename, ftpClient, azureBlobClient);
         String bytes = """
                 codice_IPA,cf_gestore,cenominazione,comicilio_digitale,anac_incaricato,anac_abilitato
                 aaaaaaa,tax_code,denominazione,test@pec.it,false,false
@@ -40,7 +45,8 @@ class AnacDataFromFTPConnectorImplTest {
     @Test
     void getStationsFileNotFound() {
         final String filename = "test.csv";
-        AnacDataConnector anacDataConnector = new AnacDataFromFTPConnectorImpl(filename, ftpClient);
+        final String directory = "/test/";
+        AnacDataConnector anacDataConnector = new AnacDataFromFTPConnectorImpl(directory, filename, ftpClient, azureBlobClient);
         when(ftpClient.getFile(anyString())).thenReturn(Optional.empty());
         final  Optional<InputStream> inputStream = anacDataConnector.getANACData();
         assertTrue(inputStream.isEmpty());

--- a/connector/ftp/src/test/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImplTest.java
+++ b/connector/ftp/src/test/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImplTest.java
@@ -36,7 +36,7 @@ class AnacDataFromFTPConnectorImplTest {
                 """;
         InputStream mockInputStream = new ByteArrayInputStream(bytes.getBytes(StandardCharsets.UTF_8));
         when(ftpClient.getFile(anyString())).thenReturn(Optional.of(mockInputStream));
-        final Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertNotNull(inputStream);
         verify(ftpClient, times(1)).getFile(anyString());
         verifyNoMoreInteractions(ftpClient);
@@ -48,7 +48,7 @@ class AnacDataFromFTPConnectorImplTest {
         final String directory = "/test/";
         AnacDataConnector anacDataConnector = new AnacDataFromFTPConnectorImpl(directory, filename, ftpClient, azureBlobClient);
         when(ftpClient.getFile(anyString())).thenReturn(Optional.empty());
-        final  Optional<InputStream> inputStream = anacDataConnector.getANACData();
+        final  Optional<ByteArrayInputStream> inputStream = anacDataConnector.getANACData();
         assertTrue(inputStream.isEmpty());
         verify(ftpClient, times(1)).getFile(any());
         verifyNoMoreInteractions(ftpClient);

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACService.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACService.java
@@ -5,5 +5,6 @@ import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
 import java.util.List;
 
 public interface ANACService {
-    List<Station> getStations();
+
+    List<Station> loadStations();
 }

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Collections;
@@ -72,9 +71,9 @@ public class ANACServiceImpl implements ANACService {
      * according to properties file.connector.type, that can assume the value SFTP or AZURE
      */
     public List<Station> getStations() {
-        Optional<InputStream> optionalInputStream = anacDataConnector.getANACData();
-        return optionalInputStream.map(inputStream -> {
-                    List<Station> stations = retrieveStationListFromCSV(inputStream);
+        Optional<ByteArrayInputStream> optionalData = anacDataConnector.getANACData();
+        return optionalData.map(data -> {
+                    List<Station> stations = retrieveStationListFromCSV(data);
                     log.debug("getStations result = {}", stations);
                     log.trace("getStations end");
                     return stations;
@@ -88,13 +87,13 @@ public class ANACServiceImpl implements ANACService {
             resourceResponse = fileStorageConnector.getFile(fileStorageFileName);
             return retrieveStationListFromCSV(new ByteArrayInputStream(resourceResponse.getData()));
         } catch (Exception e) {
-            log.error("Impossible to retrieve file ANAC. Error: {}", e.getMessage(), e);
+            log.error("Error during retrieving ANAC csv. Error: {}", e.getMessage(), e);
             return Collections.emptyList();
         }
     }
 
-    private static List<Station> retrieveStationListFromCSV(InputStream inputStream) {
-        Reader reader = new InputStreamReader(inputStream);
+    private static List<Station> retrieveStationListFromCSV(ByteArrayInputStream byteArrayInputStream) {
+        Reader reader = new InputStreamReader(byteArrayInputStream);
         CsvToBeanBuilder<Station> csvToBeanBuilder = new CsvToBeanBuilder<>(reader);
         csvToBeanBuilder.withType(AnacDataTemplate.class);
         csvToBeanBuilder.withIgnoreLeadingWhiteSpace(true);

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
@@ -2,31 +2,44 @@ package it.pagopa.selfcare.party.registry_proxy.core;
 
 import com.opencsv.bean.CsvToBeanBuilder;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.AnacDataConnector;
+import it.pagopa.selfcare.party.registry_proxy.connector.api.FileStorageConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.IndexWriterService;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.AnacDataTemplate;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.Entity;
+import it.pagopa.selfcare.party.registry_proxy.connector.model.ResourceResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class ANACServiceImpl implements ANACService {
 
-
     private final AnacDataConnector anacDataConnector;
+    private final FileStorageConnector fileStorageConnector;
+    private final String fileStorageFileName;
     private final IndexWriterService<Station> stationIndexWriterService;
+
+    public ANACServiceImpl(AnacDataConnector anacDataConnector,
+                           FileStorageConnector fileStorageConnector,
+                           @Value("${blobStorage.anac.filename}") String fileStorageFileName,
+                           IndexWriterService<Station> stationIndexWriterService) {
+        this.anacDataConnector = anacDataConnector;
+        this.fileStorageConnector = fileStorageConnector;
+        this.fileStorageFileName = fileStorageFileName;
+        this.stationIndexWriterService = stationIndexWriterService;
+    }
 
     @Scheduled(cron = "0 0 0/6 * * *")
     void updateStationIndex() {
@@ -39,18 +52,45 @@ public class ANACServiceImpl implements ANACService {
         log.trace("updated ANAC Stations index end");
     }
 
+    /**
+     * The loadStations function is used to load the stations on application startup. If file.connector.type properties is SFTP,
+     * firstly it tries to retrieve anac file from server ftp,
+     * if today's file is not present, the function retrieves the last uploaded file on azure storage.
+     * Otherwise, if file.connector.type properties is AZURE the function retrieves the last uploaded file on azure storage.
+     */
     @Override
-    public List<Station> getStations() {
-        List<Station> stations = new ArrayList<>();
-        Optional<InputStream> optionalInputStream = anacDataConnector.getANACData();
-
-        if (optionalInputStream.isPresent()) {
-            stations = retrieveStationListFromCSV(optionalInputStream.get());
+    public List<Station> loadStations() {
+        List<Station> stations = getStations();
+        if (stations.isEmpty()) {
+            return loadStationsFromAzureStorage();
         }
-
-        log.debug("getStations result = {}", stations);
-        log.trace("getStations end");
         return stations;
+    }
+
+    /**
+     * The getStations function is used to retrieve the stations from Ftp or Azure storage
+     * according to properties file.connector.type, that can assume the value SFTP or AZURE
+     */
+    public List<Station> getStations() {
+        Optional<InputStream> optionalInputStream = anacDataConnector.getANACData();
+        return optionalInputStream.map(inputStream -> {
+                    List<Station> stations = retrieveStationListFromCSV(inputStream);
+                    log.debug("getStations result = {}", stations);
+                    log.trace("getStations end");
+                    return stations;
+                })
+                .orElseGet(Collections::emptyList);
+    }
+
+    private List<Station> loadStationsFromAzureStorage() {
+        ResourceResponse resourceResponse;
+        try {
+            resourceResponse = fileStorageConnector.getFile(fileStorageFileName);
+            return retrieveStationListFromCSV(new ByteArrayInputStream(resourceResponse.getData()));
+        } catch (Exception e) {
+            log.error("Impossible to retrieve file ANAC. Error: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
     }
 
     private static List<Station> retrieveStationListFromCSV(InputStream inputStream) {

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/OpenDataLoader.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/OpenDataLoader.java
@@ -55,7 +55,7 @@ public class OpenDataLoader implements CommandLineRunner {
             categoryIndexWriterService.adds(openDataConnector.getCategories());
             aooIndexWriterService.adds(openDataConnector.getAOOs());
             uoIndexWriterService.adds(openDataConnector.getUOs());
-            stationIndexWriterService.adds(anacService.getStations());
+            stationIndexWriterService.adds(anacService.loadStations());
             ivassIndexWriterService.adds(ivassDataConnector.getInsurances());
         });
         log.trace("run end");

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImplTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.party.registry_proxy.core;
 
 import it.pagopa.selfcare.party.registry_proxy.connector.api.AnacDataConnector;
+import it.pagopa.selfcare.party.registry_proxy.connector.api.FileStorageConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.api.IndexWriterService;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.Station;
 import org.junit.jupiter.api.Assertions;
@@ -26,6 +27,11 @@ class ANACServiceImplTest {
     private ANACServiceImpl anacService;
 
     @Mock
+    private FileStorageConnector fileStorageConnector;
+
+    private String fileStorageFileName = "fileStorageFileName";
+
+    @Mock
     private AnacDataConnector anacDataConnector;
 
     @Mock
@@ -35,25 +41,25 @@ class ANACServiceImplTest {
             "00000000000,srl s.r.l.,srl@pec.it,,true,false,false";
 
     @Test
-    void getStations() {
-        anacService = new ANACServiceImpl(anacDataConnector, stationIndexWriterService);
+    void loadStations() {
+        anacService = new ANACServiceImpl(anacDataConnector, fileStorageConnector, fileStorageFileName, stationIndexWriterService);
         InputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
         when(anacDataConnector.getANACData()).thenReturn(Optional.of(inputStream));
-        Executable executable = () -> anacService.getStations();
+        Executable executable = () -> anacService.loadStations();
         Assertions.assertDoesNotThrow(executable);
     }
 
     @Test
     void getStationsEmpty() {
-        anacService = new ANACServiceImpl(anacDataConnector, stationIndexWriterService);
+        anacService = new ANACServiceImpl(anacDataConnector, fileStorageConnector, fileStorageFileName, stationIndexWriterService);
         when(anacDataConnector.getANACData()).thenReturn(Optional.empty());
-        List<Station> stationList = anacService.getStations();
+        List<Station> stationList = anacService.loadStations();
         Assertions.assertEquals(0, stationList.size());
     }
 
     @Test
     void updateStationIndex() {
-        anacService = new ANACServiceImpl(anacDataConnector, stationIndexWriterService);
+        anacService = new ANACServiceImpl(anacDataConnector, fileStorageConnector, fileStorageFileName, stationIndexWriterService);
         InputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
         when(anacDataConnector.getANACData()).thenReturn(Optional.of(inputStream));
         Executable executable = () -> anacService.updateStationIndex();

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImplTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -43,7 +42,7 @@ class ANACServiceImplTest {
     @Test
     void loadStations() {
         anacService = new ANACServiceImpl(anacDataConnector, fileStorageConnector, fileStorageFileName, stationIndexWriterService);
-        InputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
         when(anacDataConnector.getANACData()).thenReturn(Optional.of(inputStream));
         Executable executable = () -> anacService.loadStations();
         Assertions.assertDoesNotThrow(executable);
@@ -60,7 +59,7 @@ class ANACServiceImplTest {
     @Test
     void updateStationIndex() {
         anacService = new ANACServiceImpl(anacDataConnector, fileStorageConnector, fileStorageFileName, stationIndexWriterService);
-        InputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(testCaseCsv.getBytes(StandardCharsets.UTF_8));
         when(anacDataConnector.getANACData()).thenReturn(Optional.of(inputStream));
         Executable executable = () -> anacService.updateStationIndex();
         Assertions.assertDoesNotThrow(executable);

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/OpenDataLoaderTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/OpenDataLoaderTest.java
@@ -90,8 +90,6 @@ class OpenDataLoaderTest {
                 .adds(uos);
         verify(pdndIndexWriterService, times(1))
                 .adds(stations);
-        verify(anacService, times(1))
-                .getStations();
         verify(ivassIndexWriterService, times(1))
                 .adds(insuranceCompanies);
     }


### PR DESCRIPTION
**List of Changes**
- added ANAC file update in AzureStorage when retrieve new file from FTP Server
- added optional retrieving of file from Azure storage if server ftp doesn't contain file of the day

**Motivation and Context**
On start of application it try to load anac csv file from server ftp using filename that contain date of the day. If this file is not present we have an error for ANAC Station, so we have to store last retrieved file on azure storage to prevent this kind of error.

**How Has This Been Tested?**
We tested with local server ftp to check the updating of the file on azureStorage when we found file, and the recovery from  azure storage when the file of the day is not present on ftp