### PR TITLE
[SELC-4256] feat: modify nationalRegistriesConnector response management to avoid BadGatewayExceptions(502)

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImpl.java
@@ -4,12 +4,12 @@ import it.pagopa.selfcare.party.registry_proxy.connector.api.NationalRegistriesC
 import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import it.pagopa.selfcare.party.registry_proxy.connector.exception.BadGatewayException;
 import it.pagopa.selfcare.party.registry_proxy.connector.exception.InvalidRequestException;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.Businesses;
-import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressProfessionalResponse;
+import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.VerifyLegalResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.rest.utils.MaskDataUtils;
-import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -53,7 +53,8 @@ class NationalRegistriesServiceImpl implements NationalRegistriesService {
         AdEResultDetailEnum adEResultDetailEnum = AdEResultDetailEnum.fromValue(verifyLegalResponse.getVerifyLegalResultDetail().getValue());
         if(AdEResultDetailEnum.XX00 == adEResultDetailEnum){
             return verifyLegalResponse;
-        }else if(AdEResultDetailEnum.XX01 == adEResultDetailEnum || AdEResultDetailEnum.XX02 == adEResultDetailEnum){
+        }else if(AdEResultDetailEnum.XX01 == adEResultDetailEnum || AdEResultDetailEnum.XX02 == adEResultDetailEnum
+        || AdEResultDetailEnum.XXXX == adEResultDetailEnum){
             throw new InvalidRequestException("Formato dati non corretto");
         }
         throw new BadGatewayException(verifyLegalResponse.getVerifyLegalResultDetailMessage());

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/NationalRegistriesServiceImplTest.java
@@ -1,25 +1,24 @@
 package it.pagopa.selfcare.party.registry_proxy.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import it.pagopa.selfcare.party.registry_proxy.connector.api.NationalRegistriesConnector;
 import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultCodeEnum;
 import it.pagopa.selfcare.party.registry_proxy.connector.constant.AdEResultDetailEnum;
 import it.pagopa.selfcare.party.registry_proxy.connector.exception.BadGatewayException;
 import it.pagopa.selfcare.party.registry_proxy.connector.exception.InvalidRequestException;
+import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.Businesses;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressProfessionalResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.LegalAddressResponse;
 import it.pagopa.selfcare.party.registry_proxy.connector.model.nationalregistries.VerifyLegalResponse;
-import it.pagopa.selfcare.party.registry_proxy.connector.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,13 +26,8 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {NationalRegistriesServiceImpl.class})
 @ExtendWith(SpringExtension.class)
@@ -128,11 +122,12 @@ class NationalRegistriesServiceImplTest {
     /**
      * Method under test: {@link NationalRegistriesServiceImpl#verifyLegal(String, String)}
      */
-    @Test
-    void testVerifyLegalInvalidRequest() {
+    @ParameterizedTest
+    @EnumSource(value = AdEResultDetailEnum.class, names = {"XX01", "XX02", "XXXX"})
+    void testVerifyLegalInvalidRequest(AdEResultDetailEnum code) {
         VerifyLegalResponse verifyLegalResponse = new VerifyLegalResponse();
         verifyLegalResponse.setVerifyLegalResultCode(AdEResultCodeEnum.CODE_01);
-        verifyLegalResponse.setVerifyLegalResultDetail(AdEResultDetailEnum.XX01);
+        verifyLegalResponse.setVerifyLegalResultDetail(code);
         when(nationalRegistriesConnector.verifyLegal(any(), any()))
                 .thenReturn(verifyLegalResponse);
         assertThrows(InvalidRequestException.class, () -> nationalRegistriesServiceImpl.verifyLegal("42", "42"));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add check if nationalRegistriesConnector  response has "XXXX" as AdEResultDetailEnum than throw InvalidRequestException
- adjust junits

<!--- Describe your changes in detail -->

#### Motivation and Context
The BadGatewayException(502) previously thrown bringmany alert errors.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.