### PR TITLE
[SELC-4462] feat: added API to retrieve insurances by ivass code

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -910,6 +910,79 @@
         } ]
       }
     },
+    "/insurance-companies/origin/{originId}" : {
+      "get" : {
+        "tags" : [ "insurance-companies" ],
+        "summary" : "Search insurance company by its taxCode",
+        "description" : "Returns only one insurance company.",
+        "operationId" : "searchByOriginIdUsingGET",
+        "parameters" : [ {
+          "name" : "originId",
+          "in" : "path",
+          "description" : "insurance company's IVASS unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InsuranceCompanyResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/insurance-companies/{taxId}" : {
       "get" : {
         "tags" : [ "insurance-companies" ],

--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/IvassDataConnectorImpl.java
@@ -60,12 +60,10 @@ public class IvassDataConnectorImpl implements IvassDataConnector {
         } catch (Exception e) {
             log.error("Impossible to acquire data for IVASS. Error: {}", e.getMessage(), e);
         }
-        //log.debug("getInsurances result = {}", companies);
         log.trace("getInsurances end");
         return companies
                 .stream()
-                .filter(company -> StringUtils.hasText(company.getTaxCode())
-                        && StringUtils.hasText(company.getDigitalAddress())
+                .filter(company -> StringUtils.hasText(company.getDigitalAddress())
                         && workTypesAdmitted.contains(company.getWorkType())
                         && registryTypesAdmitted
                         .stream()

--- a/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/InsuranceCompanyToDocumentConverter.java
+++ b/connector/lucene/src/main/java/it/pagopa/selfcare/party/registry_proxy/connector/lucene/converter/InsuranceCompanyToDocumentConverter.java
@@ -21,7 +21,7 @@ public class InsuranceCompanyToDocumentConverter implements Function<InsuranceCo
             doc.add(new StringField(Entity.ENTITY_TYPE.toString(), Entity.INSURANCE_COMPANY.toString(), Field.Store.YES));
             doc.add(new StringField(ID.toString(), company.getId(), Field.Store.YES));
             doc.add(new StoredField(ORIGIN.toString(), company.getOrigin().toString()));
-            doc.add(new StoredField(ORIGIN_ID.toString(), company.getOriginId()));
+            doc.add(new StringField(ORIGIN_ID.toString(), company.getOriginId(), Field.Store.YES));
             doc.add(new SortedDocValuesField(DESCRIPTION.toString(), new BytesRef(company.getDescription())));
             doc.add(new TextField(DESCRIPTION.toString(), company.getDescription(), Field.Store.YES));
             doc.add(new StoredField(TAX_CODE.toString(), company.getTaxCode()));

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassService.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassService.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface IvassService {
     QueryResult<InsuranceCompany> search(Optional<String> searchText, int page, int limit);
     InsuranceCompany findByTaxCode(String taxId);
+    InsuranceCompany findByOriginId(String ivassCode);
 }
 

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImpl.java
@@ -42,6 +42,21 @@ public class IvassServiceImpl implements IvassService {
     }
 
     @Override
+    public InsuranceCompany findByOriginId(String originId) {
+        log.trace("findByIvassCode start");
+        final List<InsuranceCompany> companies = indexSearchService.findById(InsuranceCompany.Field.ORIGIN_ID, originId.toUpperCase());
+        if (companies.isEmpty()) {
+            throw new ResourceNotFoundException();
+        } else if (companies.size() > 1) {
+            throw new TooManyResourceFoundException();
+        }
+        final InsuranceCompany company = companies.get(0);
+        log.debug("findByIvassCode result = {}", company);
+        log.trace("findByIvassCode end");
+        return company;
+    }
+
+    @Override
     public QueryResult<InsuranceCompany> search(Optional<String> searchText, int page, int limit) {
         log.trace("search start");
         log.debug("search searchText = {}, page = {}, limit = {}", searchText, page, limit);

--- a/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImplTest.java
@@ -39,6 +39,17 @@ class IvassServiceImplTest {
         assertThrows(ResourceNotFoundException.class, executable);
     }
 
+    @Test
+    void findByOriginId_ResourceNotFound() {
+        // given
+        final String originId = "originId";
+        when(indexSearchService.findById(any(), anyString()))
+                .thenReturn(List.of());
+        // when
+        final Executable executable = () -> ivassService.findByOriginId(originId);
+        // then
+        assertThrows(ResourceNotFoundException.class, executable);
+    }
 
     @Test
     void findById_TooManyResourceFound() {
@@ -54,6 +65,19 @@ class IvassServiceImplTest {
     }
 
     @Test
+    void findByOriginId_TooManyResourceFound() {
+        // given
+        final String originId = "originId";
+        final DummyInsuranceCompany dummyCompany = new DummyInsuranceCompany();
+        when(indexSearchService.findById(any(), anyString()))
+                .thenReturn(List.of(dummyCompany, dummyCompany));
+        // when
+        final Executable executable = () -> ivassService.findByOriginId(originId);
+        // then
+        assertThrows(TooManyResourceFoundException.class, executable);
+    }
+
+    @Test
     void findById_found() {
         // given
         final String taxId = "taxId";
@@ -64,6 +88,21 @@ class IvassServiceImplTest {
                 .thenReturn(List.of(dummyCompany));
         // when
         final InsuranceCompany result = ivassService.findByTaxCode(taxId);
+        // then
+        assertSame(dummyCompany, result);
+    }
+
+    @Test
+    void findByOriginId_found() {
+        // given
+        final String originId = "originId";
+        final DummyInsuranceCompany dummyCompany = new DummyInsuranceCompany();
+        dummyCompany.setId("id");
+        dummyCompany.setOriginId("originId");
+        when(indexSearchService.findById(any(), anyString()))
+                .thenReturn(List.of(dummyCompany));
+        // when
+        final InsuranceCompany result = ivassService.findByOriginId(originId);
         // then
         assertSame(dummyCompany, result);
     }

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -50,10 +50,10 @@ public class IvassController {
     @ApiOperation(value = "${swagger.api.insurance-company.search.byId.summary}", notes = "${swagger.api.insurance-company.search.byId.notes}")
     public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
                                                      @PathVariable("originId") String originId) {
-        log.trace("searchByTaxCode start");
+        log.trace("searchByOriginId start");
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
-        log.debug("searchByTaxCode result = {}", insuranceCompany);
-        log.trace("searchByTaxCode end");
+        log.debug("searchByOriginId result = {}", insuranceCompany);
+        log.trace("searchByOriginId end");
         return insuranceCompany;
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -45,12 +45,24 @@ public class IvassController {
         return insuranceCompany;
     }
 
+    @GetMapping("/origin/{originId}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "${swagger.api.insurance-company.search.byId.summary}", notes = "${swagger.api.insurance-company.search.byId.notes}")
+    public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
+                                                     @PathVariable("originId") String originId) {
+        log.trace("searchByTaxCode start");
+        final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
+        log.debug("searchByTaxCode result = {}", insuranceCompany);
+        log.trace("searchByTaxCode end");
+        return insuranceCompany;
+    }
+
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.api.insurance-company.search.summary}", notes = "${swagger.api.insurance-company.search.notes}")
     public InsuranceCompaniesResource search(@ApiParam("${swagger.model.*.search}")
                                              @RequestParam(value = "search", required = false)
-                                                 Optional<String> search,
+                                             Optional<String> search,
                                              @ApiParam(value = "${swagger.model.*.page}")
                                              @RequestParam(value = "page", required = false, defaultValue = "1")
                                              Integer page,

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -51,7 +51,6 @@ public class IvassController {
     public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
                                                      @PathVariable("originId") String originId) {
         log.trace("searchByOriginId start");
-        log.debug("searchByOriginId parameter = {}", originId.replaceAll("[\r\n]", ""));
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
         log.debug("searchByOriginId result = {}", insuranceCompany);
         log.trace("searchByOriginId end");

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -51,7 +51,7 @@ public class IvassController {
     public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
                                                      @PathVariable("originId") String originId) {
         log.trace("searchByOriginId start");
-        log.debug("searchByTaxCode parameter = {}", originId);
+        log.debug("searchByOriginId parameter = {}", originId.replaceAll("[\r\n]", ""));
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
         log.debug("searchByOriginId result = {}", insuranceCompany);
         log.trace("searchByOriginId end");

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -38,7 +38,9 @@ public class IvassController {
     public InsuranceCompanyResource searchByTaxCode(@ApiParam("${swagger.model.insurance-company.taxCode}")
                                                     @PathVariable("taxId") String taxId) {
         log.trace("searchByTaxCode start");
-        log.debug("searchByTaxCode parameter = {}", taxId);
+        if (taxId.matches("\\w*")) {
+            log.debug("searchByTaxCode parameter = {}", taxId);
+        }
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByTaxCode(taxId));
         log.debug("searchByTaxCode result = {}", insuranceCompany);
         log.trace("searchByTaxCode end");
@@ -51,6 +53,9 @@ public class IvassController {
     public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
                                                      @PathVariable("originId") String originId) {
         log.trace("searchByOriginId start");
+        if (originId.matches("\\w*")) {
+            log.debug("searchByOriginId parameter = {}", originId);
+        }
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
         log.debug("searchByOriginId result = {}", insuranceCompany);
         log.trace("searchByOriginId end");

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -51,6 +51,7 @@ public class IvassController {
     public InsuranceCompanyResource searchByOriginId(@ApiParam("${swagger.model.insurance-company.originId}")
                                                      @PathVariable("originId") String originId) {
         log.trace("searchByOriginId start");
+        log.debug("searchByTaxCode parameter = {}", originId);
         final InsuranceCompanyResource insuranceCompany = insuranceCompanyMapper.toResource(ivassService.findByOriginId(originId));
         log.debug("searchByOriginId result = {}", insuranceCompany);
         log.trace("searchByOriginId end");

--- a/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassControllerTest.java
@@ -42,6 +42,9 @@ class IvassControllerTest {
     @MockBean
     private IvassService ivassService;
 
+    /**
+     * Method under test: {@link IvassController#searchByTaxCode(String)}
+     */
     @Test
     void findInsurance() throws Exception {
         // given
@@ -66,7 +69,39 @@ class IvassControllerTest {
                 .findByTaxCode(taxId);
         verifyNoMoreInteractions(ivassService);
     }
+    
+    /**
+     * Method under test: {@link IvassController#searchByOriginId(String)}
+     */
+    @Test
+    void findInsuranceByOriginId() throws Exception {
+        // given
+        final String originId = "originId";
+        when(ivassService.findByOriginId(any()))
+                .thenReturn(mockInstance(new DummyInsuranceCompany()));
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/origin/{originId}", originId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", notNullValue()))
+                .andExpect(jsonPath("$.originId", notNullValue()))
+                .andExpect(jsonPath("$.taxCode", notNullValue()))
+                .andExpect(jsonPath("$.description", notNullValue()))
+                .andExpect(jsonPath("$.digitalAddress", notNullValue()))
+                .andExpect(jsonPath("$.address", notNullValue()));
+        // then
 
+        verify(ivassService, times(1))
+                .findByOriginId(originId);
+        verifyNoMoreInteractions(ivassService);
+    }
+    
+
+    /**
+     * Method under test: {@link IvassController#searchByTaxCode(String)}
+     */
     @Test
     void findInsuranceNotFound() throws Exception {
         // given
@@ -85,6 +120,30 @@ class IvassControllerTest {
         verifyNoMoreInteractions(ivassService);
     }
 
+    /**
+     * Method under test: {@link IvassController#searchByOriginId(String)}
+     */
+    @Test
+    void findInsuranceNyOriginIdNotFound() throws Exception {
+        // given
+        final String originId = "originId";
+        when(ivassService.findByOriginId(any()))
+                .thenThrow(ResourceNotFoundException.class);
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/origin/{originId}", originId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound());
+        // then
+        verify(ivassService, times(1))
+                .findByOriginId(originId);
+        verifyNoMoreInteractions(ivassService);
+    }
+
+    /**
+     * Method under test: {@link IvassController#search(Optional, Integer, Integer)}
+     */
     @Test
     void search() throws Exception {
         // given
@@ -118,6 +177,9 @@ class IvassControllerTest {
         verifyNoMoreInteractions(ivassService);
     }
 
+    /**
+     * Method under test: {@link IvassController#search(Optional, Integer, Integer)}
+     */
     @Test
     void search_defaultInputParams() throws Exception {
         // given


### PR DESCRIPTION
#### List of Changes

- Added API to retrieve insurances by ivass code
- Removed filter into writer index for companies with not empty fiscal code

#### Motivation and Context

This development  is necessary to alow onboarding to foreigner companies

#### How Has This Been Tested?

I have deployed the feature branch in DEV and tested the API **insurance-companies/origin/{code}**
