### PR TITLE
[SELC-4622] feat: added deprecated on method findByTaxCode for IVASS registry

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/IvassServiceImpl.java
@@ -25,6 +25,10 @@ public class IvassServiceImpl implements IvassService {
         this.indexSearchService = indexSearchService;
     }
 
+    /**
+     * @deprecated method has been deprecated because a new method has been implemented.
+     */
+    @Deprecated(forRemoval = true)
     @Override
     public InsuranceCompany findByTaxCode(String taxId) {
         log.trace("findByTaxCode start");

--- a/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
+++ b/web/src/main/java/it/pagopa/selfcare/party/registry_proxy/web/controller/IvassController.java
@@ -32,6 +32,10 @@ public class IvassController {
         this.insuranceCompanyMapper = insuranceCompanyMapper;
     }
 
+    /**
+     * @deprecated since a new version has been implemented
+     */
+    @Deprecated(forRemoval = true)
     @GetMapping("/{taxId}")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.api.insurance-company.search.byId.summary}", notes = "${swagger.api.insurance-company.search.byId.notes}")


### PR DESCRIPTION
#### List of Changes

Added deprecated annotation on API findByTaxCode for IVASS registry

#### Motivation and Context

This API and related service have been marked as deprecated for removale since the search into registry will be done with the IVASS code and not with fiscal code (in some case this field can be empty)
