### PR TITLE
[SELC-4443] fix: added logs to detect anac services implementation 

### DIFF
--- a/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImpl.java
+++ b/connector/azure_storage/src/main/java/it/pagopa/selfcare/party/connector/azure_storage/AnacDataConnectorImpl.java
@@ -15,8 +15,7 @@ import java.util.Optional;
 @Slf4j
 @ConditionalOnProperty(
         value = "file.connector.type",
-        havingValue = "azure",
-        matchIfMissing = true)
+        havingValue = "azure")
 public class AnacDataConnectorImpl implements AnacDataConnector {
 
     private final FileStorageConnector fileStorageConnector;

--- a/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
+++ b/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
@@ -49,11 +49,11 @@ public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
     @Override
     public Optional<ByteArrayInputStream> getANACData() {
         String fileName = createFileName();
-        log.trace("getANACData on filename: {} start", fileName);
+        log.trace("getANACDataFromFTP on filename: {} start", fileName);
         Optional<InputStream> optionalFile = ftpConnector.getFile(directory + fileName);
         return optionalFile.flatMap(inputStream -> {
             Optional<ByteArrayInputStream> opt = updateFileOnAzureStorageAndRetrieveInputStream(inputStream);
-            log.debug("getANACData on filename from ftp: {} end", fileName);
+            log.debug("getANACDataFromFTP on filename from ftp: {} end", fileName);
             return opt;
         });
 
@@ -61,13 +61,15 @@ public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
 
     private Optional<ByteArrayInputStream> updateFileOnAzureStorageAndRetrieveInputStream(InputStream inputStream){
         try {
+            log.info("START upload file on azure after download from FTP");
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             IOUtils.copy(inputStream, out);
             byte[] bytes = out.toByteArray();
             azureBlobClient.uploadFile(new ByteArrayInputStream(bytes), anacFileName);
+            log.info("END upload file on azure after download from FTP");
             return Optional.of(new ByteArrayInputStream(bytes));
         } catch (IOException e) {
-            log.error("Error during retrieving ANAC csv. Error: {}", e.getMessage(), e);
+            log.error("Error during retrieving ANAC csv from FTP. Error: {}", e.getMessage(), e);
             return Optional.empty();
         }
     }

--- a/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
+++ b/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/AnacDataFromFTPConnectorImpl.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 @Slf4j
 @ConditionalOnProperty(
         value = "file.connector.type",
-        havingValue = "sftp")
+        havingValue = "sftp",
+        matchIfMissing = true)
 @PropertySource("classpath:config/ftp-config.properties")
 public class AnacDataFromFTPConnectorImpl implements AnacDataConnector {
 

--- a/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/client/AnacFTPClient.java
+++ b/connector/ftp/src/main/java/it/pagopa/selfcare/party/connector/ftp/client/AnacFTPClient.java
@@ -38,6 +38,7 @@ public class AnacFTPClient implements FTPConnector {
 
     @Override
     public Optional<InputStream> getFile(String fileName) {
+        log.info("START retrieve {} from ftp", fileName);
         Optional<InputStream> optionalInputStream = Optional.empty();
         ChannelSftp channelSftp = new ChannelSftp();
         try {
@@ -49,6 +50,7 @@ public class AnacFTPClient implements FTPConnector {
         } finally {
             channelSftp.exit();
         }
+        log.info("END retrieve {} from ftp", fileName);
         return optionalInputStream;
     }
 

--- a/connector/ftp/src/main/resources/config/ftp-config.properties
+++ b/connector/ftp/src/main/resources/config/ftp-config.properties
@@ -4,3 +4,4 @@ anac.ftp.ip=${ANAC_FTP_IP:127.0.0.1}
 anac.ftp.known-host=${ANAC_FTP_KNOWN_HOST:default}
 anac.ftp.user=${ANAC_FTP_USER:anonymous}
 anac.ftp.password=${ANAC_FTP_PASSWORD:password}
+file.connector.type=sftp

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
@@ -40,7 +40,7 @@ public class ANACServiceImpl implements ANACService {
         this.stationIndexWriterService = stationIndexWriterService;
     }
 
-    @Scheduled(cron = "0 0 0/6 * * *")
+    @Scheduled(cron = "0 0/10 * * * ?")
     void updateStationIndex() {
         log.trace("start update ANAC Stations index");
         List<Station> stations = getStations();

--- a/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/party/registry_proxy/core/ANACServiceImpl.java
@@ -40,7 +40,7 @@ public class ANACServiceImpl implements ANACService {
         this.stationIndexWriterService = stationIndexWriterService;
     }
 
-    @Scheduled(cron = "0 0/10 * * * ?")
+    @Scheduled(cron = "0 0 0/6 * * *")
     void updateStationIndex() {
         log.trace("start update ANAC Stations index");
         List<Station> stations = getStations();


### PR DESCRIPTION
#### List of Changes

- Added logs to detect anac services implementation 
- Changed implementation of anac services from azure to sftp

#### Motivation and Context

In order to not upload manually csv file for anac stations, the anac service has been switched to sftp

#### How Has This Been Tested?

I have deployed the ms in DEV and tested the startup of service and the scheduled process to upgrade file

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.